### PR TITLE
Add all params except for prioritisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,14 @@ than or equal to `start`.
 
 
 ```js
-//not yet implemented
 Parameters.withMaxVaccine(timesteps = [0], maxVaccines = [0]);
 ```
 
-This models changes in the number of available vaccines over time. At each
+This models changes in the number of vaccines available each day. At each
 timestep in `timesteps` the corresponding number of `maxVaccines` will be made
 available. The `timesteps` and `maxVaccines` arrays must be the same size.
 
 ```js
-//not yet implemented
 Parameters.withVaccineEfficacy(diseaseEfficacy = .95, infectionEfficacy = .95)
 ```
 
@@ -184,7 +182,7 @@ const results = runModel(
 
 Note: this package does not provide estimations of beta
 
-### Vaccines becoming available (to be implemented)
+### Vaccines becoming available
 
 We can simulate 100,000 vaccines becoming available at timestep 20.
 
@@ -205,7 +203,7 @@ const results = runModel(
 );
 ```
 
-### Vaccine profile (to be implemented)
+### Vaccine profile
 
 We can simulate a vaccine which only mitigates onward infection.
 

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,4 +1,4 @@
-import { approxEqualArray } from './utils.js';
+import { approxEqualArray } from '../test/utils.js';
 import { flattenNested } from '../src/utils.js';
 import json from '@rollup/plugin-json';
 

--- a/test/test_parameters.js
+++ b/test/test_parameters.js
@@ -4,6 +4,7 @@ import sinon from 'sinon'
 import default_params from '../data/default_parameters.json'
 
 import { createParameters } from '../src/parameters.js'
+import { expectMatrixEqual } from './utils.js'
 
 import stlucia from '../data/LCA.json'
 
@@ -59,6 +60,59 @@ describe('createParameters', function() {
     expect(ICU_beds[0]).to.be.equal(3000);
   });
 
+  it('parameterises efficacy correctly', function() {
+    const actual = createParameters(
+      stlucia.S_0,
+      stlucia.E1_0,
+      stlucia.contactMatrix,
+      0,
+      3,
+      1000,
+      3000
+    ).withVaccineEfficacy(.7, .99);
+
+    const {
+      vaccine_efficacy_infection,
+      prob_hosp,
+      ...others
+    } = actual._toOdin();
+
+    const defaultProbHosp = [0.000840764,0.001182411,0.001662887,0.002338607,
+      0.003288907,0.004625365,0.006504897,0.009148183,0.012865577,0.018093546,
+      0.025445917,0.035785947,0.050327683,0.0707785,0.099539573,0.1399878,
+      0.233470395];
+
+    const vaccinatedProbHosp = [0.0002522292,0.0003547233,0.0004988661,
+      0.0007015821,0.0009866721,0.0013876095,0.0019514691,0.0027444549,
+      0.0038596731,0.0054280638,0.0076337751,0.0107357841,0.0150983049,
+      0.0212335500,0.0298618719,0.0419963400,0.0700411185];
+
+    expectMatrixEqual(
+      vaccine_efficacy_infection,
+      [
+        Array(17).fill(1),
+        Array(17).fill(1),
+        Array(17).fill(1),
+        Array(17).fill(.01),
+        Array(17).fill(.01),
+        Array(17).fill(1),
+      ]
+    )
+
+    expectMatrixEqual(
+      prob_hosp,
+      [
+        defaultProbHosp,
+        defaultProbHosp,
+        defaultProbHosp,
+        vaccinatedProbHosp,
+        vaccinatedProbHosp,
+        defaultProbHosp
+      ]
+    )
+
+  });
+
   it('Throws error on late start time', function() {
     let params = createParameters(
       stlucia.S_0,
@@ -112,6 +166,22 @@ describe('createParameters', function() {
         -3,
         3000
       )
+    }).to.throw(Error);
+  });
+
+  it('Throws error on mismatched max_vaccine', function() {
+    const params = createParameters(
+      stlucia.S_0,
+      stlucia.E1_0,
+      stlucia.contactMatrix,
+      0,
+      3,
+      1000,
+      3000
+    );
+
+    expect(() => {
+      params.withMaxVaccine([0, 30], [0])
     }).to.throw(Error);
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai'
+
 export function approxEqualArray(x, y, tolerance) {
   if (y.length !== x.length) {
     throw Error("Incompatible arrays");
@@ -23,4 +25,18 @@ export function approxEqualArray(x, y, tolerance) {
     xy /= scale;
   }
   return xy < tolerance;
+}
+
+export function expectMatrixEqual(x, y, tolerance=1e-4) {
+  expect(x.length).to.be.equal(y.length);
+  expect(x[0].length).to.be.equal(y[0].length);
+  for (let i = 0; i < x.length; i++) {
+    for (let j = 0; j < x[0].length; j++) {
+      expect(x[i][j]).to.be.closeTo(
+        y[i][j],
+        tolerance,
+        `matrix index ${i}, ${j} is off by ${i - j}`
+      )
+    }
+  }
 }


### PR DESCRIPTION
Add maxVaccines and vaccineProfile parameters to nimue.js

Users can now do:

```js
const parameters = getParameters(...)
  .withMaxVaccines([0, 272], [0, 1000000]) // sets 1M daily vaccines to become available on timestep 272
  .withVaccineEfficacy(.7, .9) // sets vaccine disease efficacy to .7 and infection efficacy to .9
```

To parameterise their model runs