### PR TITLE
Expose full dopri control via runModel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN R -e 'install.packages( \
   c("odin", "deSolve", "jsonlite", "remotes"))'
 
 RUN R -e 'Sys.setenv(DOWNLOAD_STATIC_LIBV8 = 1); \
-  remotes::install_github(c("jeroen/V8", "mrc-ide/odin.js", \
-  "mrc-ide/nimue@b0c9bcbfaddb7a1dc282feef011b865f47b98004"))'
+  remotes::install_github(c("jeroen/V8", "mrc-ide/odin.js", "mrc-ide/dde", \
+  "mrc-ide/nimue@b38aa37"))'
 
 # Install node
 RUN apt-get install -y curl

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -2,6 +2,9 @@ args = commandArgs(trailingOnly=TRUE)
 if (length(args) != 2) {
   stop("This script requires the model spec and the output path")
 }
+if (packageVersion("odin.js") < "0.1.11") {
+  stop("Upgrade odin.js to at least 0.1.11")
+}
 odin.js::odin_js_bundle(
   file.path(
     system.file('odin', package = 'nimue', mustWork = TRUE),

--- a/README.md
+++ b/README.md
@@ -126,11 +126,16 @@ Sets the duration of vaccine efficacy in the model
 outputs.
 
 ```js
-function runModel(parameters, atol=1e-3, rtol=1e-3)
+function runModel(parameters, control)
 ```
 
-The atol and rtol parameters are for absolute and relative tolerances for the
-ODE solver.
+The `control` paramer is a dict that may take elements:
+
+* `atol`: absolute tolerance (e.g., 1e-5)
+* `rtol`: relative tolerance (e.g., 1e-5; generally set this to the same as `atol`)
+* `stepSizeMin`: smallest allowable step size
+* `stepSizeMinAllow`: boolean, if `true` then we continue after hitting `stepSizeMin` and do not reduce the step size further
+* `stepSizeMax`: maximum allowble step size; if we hit this we take steps of no larger than this size but always continue
 
 `runModel` will return object with the following keys:
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 import { getModel } from '../build/nimue_odin.js';
 import { reffRaw } from './reff.js';
 
-export const runModel = function(parameters, atol=1e-4, rtol=1e-4) {
+export const runModel = function(parameters, control = null) {
+  if (control === null) {
+    control = {atol: 1e-4, rtol: 1e-4};
+  }
 
   const model = getModel();
   const mod = new model(parameters._toOdin(), 'ignore');
@@ -11,7 +14,7 @@ export const runModel = function(parameters, atol=1e-4, rtol=1e-4) {
     t.push(timeStart + i * dt);
   }
 
-  return mod.run(t, null, null, atol, rtol);
+  return mod.run(t, null, control);
 };
 
 export function reff(output, beta, population, parameters, mixingMatrix, tSubset = null) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { reffRaw } from './reff.js';
 
 export const runModel = function(parameters, control = null) {
   if (control === null) {
-    control = {atol: 1e-4, rtol: 1e-4};
+    control = {atol: 1e-4, rtol: 1e-4, stepSizeMin: 0.005, stepSizeMax: 2, stepSizeMinAllow: true};
   }
 
   const model = getModel();


### PR DESCRIPTION
This is a breaking change for the interface as the previous args have gone, so call like:


```
runModel(p, a, b)
```

becomes

```
runModel(p, {atol: a, rtol: b})
```